### PR TITLE
security fix: anonymous user was able access bbrf database

### DIFF
--- a/bbrf-init.sh
+++ b/bbrf-init.sh
@@ -23,7 +23,7 @@ curl -X PUT -X PUT $COUCHDB"/_users/org.couchdb.user:bbrf" -u $AUTH \
 curl -X PUT $COUCHDB"bbrf" -u $AUTH -s > /dev/null
 
 # grant access rights to the new database
-curl -X PUT $COUCHDB"bbrf/_security" -u $AUTH -d "{\"admins\": {\"names\": [\"bbrf\"],\"roles\": []}}" -s > /dev/null
+curl -X PUT $COUCHDB"bbrf/_security" -u $AUTH -d "{\"admins\": {\"names\": [\"bbrf\"],\"roles\": []}, \"members\": {\"names\": [\"bbrf\"],\"roles\": []}}" -s > /dev/null
 
 # push bbrf views
 curl -X PUT $COUCHDB"bbrf/_design/bbrf" -u $AUTH -H "Content-Type: application/json" -d @/tmp/views.json -s > /dev/null


### PR DESCRIPTION
The _security document defined only admins, there was missing members definition, what allowed any client to read/write bbrf database.

According to documentation (https://docs.couchdb.org/en/stable/api/database/security.html#):

"If the security object for a database has never been set, then the value returned will be empty."

"Having no members, any user can write regular documents (any non-design document) and read documents from the database."

"If there are any member names or roles defined for a database, then only authenticated users having a matching name or role are allowed to read documents from the database (or do a GET /{db} call)."