### PR TITLE
Fixes 504 Gateway Time-out error

### DIFF
--- a/proxy/nginx.conf
+++ b/proxy/nginx.conf
@@ -22,7 +22,7 @@ server {
    proxy_redirect off;
    proxy_http_version 1.1;
    proxy_request_buffering off;
-
+   proxy_read_timeout 3600;
    client_max_body_size 4g;
  }
 }


### PR DESCRIPTION
On sending the super large POST request(around 10mb) nginx gets time out and gives 504 Gateway Time-out error. This fixes that.