### PR TITLE
CORS Failure fixed 

### DIFF
--- a/couchdb/bbrf-init.sh
+++ b/couchdb/bbrf-init.sh
@@ -35,4 +35,8 @@ curl -X PUT $COUCHDB"_node/_local/_config/httpd/enable_cors" -u $AUTH -d '"true"
 curl -X PUT $COUCHDB"_node/_local/_config/cors/origins" -u $AUTH -d '"https://bbrf.me"' -s > /dev/null
 curl -X PUT $COUCHDB"_node/_local/_config/cors/credentials" -u $AUTH -d '"true"' -s > /dev/null
 
+
+curl -X PUT "$COUCHDB"_node/_local/_config/cors/headers -u $AUTH -d '"accept, authorization, content-type, origin, referer"' -s > /dev/null
+curl -X PUT "$COUCHDB"_node/_local/_config/cors/methods -u $AUTH -d '"GET, PUT, POST, HEAD, DELETE"' -s > /dev/null 
+
 echo "[BBRF] Initialization complete"


### PR DESCRIPTION
Hey @honoki , 

I fixed the issue https://github.com/honoki/bbrf-dashboard/issues/4 related to CORS failure. Firefox does issue an OPTIONS methods payloaded with Access-Control-Request-Headers and Access-Control-Request-Method
	GET that need to be set on the server side to acknowledge the pre flight blocking options request.

The fix is dead simple please check the two lines file changes

regards
@Sim4n6  